### PR TITLE
Fix non-DarkRP crashing issue.

### DIFF
--- a/lua/autorun/darkrp-full-classic-advert.lua
+++ b/lua/autorun/darkrp-full-classic-advert.lua
@@ -1,6 +1,7 @@
 local function init()
 	if not DarkRP then
-		return print("DarkRP Classic Advert tried to run, but DarkRP wasn't declared!")
+		print("DarkRP Classic Advert tried to run, but DarkRP wasn't declared!")
+		return
 	end
 
 	DarkRP.removeChatCommand("advert")

--- a/lua/autorun/darkrp-full-classic-advert.lua
+++ b/lua/autorun/darkrp-full-classic-advert.lua
@@ -1,4 +1,8 @@
 local function init()
+	if not DarkRP then
+		return print("DarkRP Classic Advert tried to run, but DarkRP wasn't declared!")
+	end
+
 	DarkRP.removeChatCommand("advert")
 	DarkRP.declareChatCommand({
 		command = "advert",


### PR DESCRIPTION
Fixes #2.
Don't crash if DarkRP isn't being ran.

First line of init now returns if DarkRP isn't declared, preventing issues in (ie) sandbox where the DarkRP table isn't declared.